### PR TITLE
Allow gcov binary path to be configurable from workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
           "gcovViewer.gcovBinary": {
             "type": "string",
             "title": "Gcov Binary",
-            "scope": "machine",
+            "scope": "machine-overridable",
             "description": "Path to the gcov binary",
             "default": "gcov"
           },


### PR DESCRIPTION
Make GcovBinary parameter configurable from both user and workspace.

Resolves #27